### PR TITLE
Update README.md using measureit instead of measureit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To measure the energy consumed by the machine during the execution of the functi
 
 	pyRAPL.setup() 
 
-	@pyRAPL.measure
+	@pyRAPL.measureit
 	def foo():
 		# Instructions to be evaluated.
 
@@ -52,7 +52,7 @@ By default, **pyRAPL** monitors all the available devices of the CPU sockets.
 
 	pyRAPL.setup(devices=[pyRAPL.Device.PKG], socket_ids=[1])
 
-	@pyRAPL.measure
+	@pyRAPL.measureit
 	def foo():
 		# Instructions to be evaluated.
 
@@ -71,7 +71,7 @@ As an example, if you want to run the evaluation 100 times:
 	pyRAPL.setup()
 	
 	
-	@pyRAPL.measure(number=100)
+	@pyRAPL.measureit(number=100)
 	def foo():
 		# Instructions to be evaluated.
 
@@ -91,7 +91,7 @@ As an example, if you want to write the recorded energy consumption in a .csv fi
 	
 	csv_output = pyRAPL.outputs.CSVOutput('result.csv')
 	
-	@pyRAPL.measure(output=csv_output)
+	@pyRAPL.measureit(output=csv_output)
 	def foo():
 		# Instructions to be evaluated.
 


### PR DESCRIPTION
Hi,

Running the following,

```py
import pyRAPL

# sudo chmod -R a+r /sys/class/powercap/intel-rapl
pyRAPL.setup()

@pyRAPL.measureit
def foo():
  import autosubmit


foo()
```

After doing a `pip install pyrapl` resulted in an error. Looking at the `__init__.py` [here](https://github.com/powerapi-ng/pyRAPL/blob/6c4f57c3dc482b7f240dd8a39e27b1a8474d1a43/pyRAPL/__init__.py#L27), I found the `measureit`, and that worked (after [this other workaround](https://github.com/powerapi-ng/pyRAPL/issues/17#issuecomment-1962382719)).

Thanks