### PR TITLE
[BUG FIX]: Preventing iteration over None value

### DIFF
--- a/pyRAPL/result.py
+++ b/pyRAPL/result.py
@@ -49,6 +49,6 @@ class Result:
         """
 
         _duration = self.duration / number
-        _pkg = [j / number for j in self.pkg]
-        _dram = [j / number for j in self.dram]
+        _pkg = [j / number for j in self.pkg] if self.pkg else None
+        _dram = [j / number for j in self.dram] if self.dram else None
         return Result(self.label, self.timestamp, _duration, _pkg, _dram)


### PR DESCRIPTION
### [BUG FIX]: Preventing iteration over None value 

This PR addresses the case when either `Result.pkg` or `Result.dram` are `None` in `results.py`. 
That happens when the lists are not provided, e.g. the quantities are not measured, and the default value `None` is kept: 
```
pkg: Optional[List[float]] = None
dram: Optional[List[float]] = None
```
In that case the function `__truediv__()` will try to iterate over the default value `None` and throws an error.

### Example
The example on the official [documentation](https://pyrapl.readthedocs.io/en/latest/quickstart.html):
```
import pyRAPL
pyRAPL.setup()

@pyRAPL.measureit(number=100)
def foo():
    # Instructions to be evaluated.

for _ in range(100):
    foo()
```
yields the following error for systems not providing RAM energy consumption measurements:
```
File "/.../lib/python3.8/site-packages/pyRAPL/measurement.py", line 123, in wrapper_measure
    sensor._results = sensor._results / number
  File "/.../lib/python3.8/site-packages/pyRAPL/result.py", line 53, in __truediv__
    _dram = [j / number for j in self.dram] #if self.dram else None
TypeError: 'NoneType' object is not iterable
```
The [fix](https://github.com/powerapi-ng/pyRAPL/commit/16015d4e2dd085b65e75c5ad60dd224cec7cb598) makes sure to skip `None` values for `self.pkg` or `self.dram` when averaging, e.g. not trying to iterate over them. 
