### PR TITLE
[Doc] Updating documentation: Running the test multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can append the device `pyRAPL.Device.DRAM` to the `devices` parameter list t
 ## Running the test multiple times 
 
 For short functions, you can configure the number of runs and it will calculate the mean energy consumption of all runs. 
-As an example, if you want to run the evaluation 100 times:
+As an example if you want to average over 100 runs and repeat the experiment 20 times:
 ```python
 	import pyRAPL
 
@@ -75,7 +75,7 @@ As an example, if you want to run the evaluation 100 times:
 	def foo():
 		# Instructions to be evaluated.
 
-	for _ in range(100):
+	for _ in range(20):
 		foo()
 ```	
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ Running the test multiple times
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For short functions, you can configure the number of runs and it will calculate the mean energy consumption of all runs. 
-As an example if you want to run the evaluation 100 times ::
+As an example if you want to average over 100 runs and repeat the experiment 20 times::
 
   import pyRAPL
 
@@ -66,7 +66,7 @@ As an example if you want to run the evaluation 100 times ::
   def foo():
       # Instructions to be evaluated.
 
-  for _ in range(100):
+  for _ in range(20):
       foo()
 
 


### PR DESCRIPTION
### [Doc] Updating documentation: Running the test multiple times

This PR improves the section 'Running the test multiple times' in the [readme](https://github.com/powerapi-ng/pyRAPL/blob/master/README.md) and [documentation](https://github.com/powerapi-ng/pyRAPL/blob/master/docs/quickstart.rst). The current description is confusing and can be understood wrong:
```
import pyRAPL

  pyRAPL.setup()
	
  @pyRAPL.measureit(number=100)
  def foo():
      # Instructions to be evaluated.

  for _ in range(100):
      foo()

```
This code executes 100 experiments with 100 runs each, and does not only average over 100 runs as described. 

In order to make things more clear, [this](https://github.com/powerapi-ng/pyRAPL/commit/41120f21ccc2fb7c65e34f436850a0e4dda0c9a0) commit changes the number of experiments to 20 and updates the description by distinguishing between runs and experiments.  