### PR TITLE
[BUG FIX]: TypeError in Buffered Output when dram is None

### DIFF
--- a/pyRAPL/outputs/buffered_output.py
+++ b/pyRAPL/outputs/buffered_output.py
@@ -48,7 +48,7 @@ class BufferedOutput(Output):
         for i in range(len(result.pkg)):
             x['socket'] = i
             x['pkg'] = result.pkg[i]
-            x['dram'] = result.dram[i]
+            x['dram'] = result.dram[i] if result.dram else None
             self._buffer.append(x.copy())
 
     @property

--- a/pyRAPL/outputs/dataframeoutput.py
+++ b/pyRAPL/outputs/dataframeoutput.py
@@ -22,30 +22,15 @@ import time
 import pandas
 
 from pyRAPL import Result
-from pyRAPL.outputs import Output
+from pyRAPL.outputs import BufferedOutput
 
 
-class DataFrameOutput(Output):
+class DataFrameOutput(BufferedOutput):
     """
     Append recorded data to a pandas Dataframe
     """
     def __init__(self):
-        Output.__init__(self)
-        self._data_frame = pandas.DataFrame(columns=list(Result.__annotations__.keys()) + ["socket"])
-
-    def add(self, result):
-        """
-        Append recorded data to the pandas Dataframe
-
-        :param result: data to add to the dataframe
-        """
-        x = dict(vars(result))
-        x['timestamp'] = time.ctime(x['timestamp'])
-        for i in range(len(result.pkg)):
-            x['socket'] = i
-            x['pkg'] = result.pkg[i]
-            x['dram'] = result.dram[i]
-            self._data_frame = self._data_frame.append(x, ignore_index=True)
+        BufferedOutput.__init__(self)
 
     @property
     def data(self) -> pandas.DataFrame:
@@ -54,4 +39,6 @@ class DataFrameOutput(Output):
 
         :return: the dataframe
         """
-        return self._data_frame
+        data_frame = pandas.DataFrame(self._buffer)
+        data_frame['timestamp'] = data_frame['timestamp'].map(lambda x: time.ctime(x))
+        return data_frame


### PR DESCRIPTION
I was using pyRAPL to measure power consumption on the AMD Ryzen 5 8640HS, which does report DRAM energy usage.  When attempting to export a series of measurements to CSV or Pandas DataFrame, I get the following error:

```
Traceback (most recent call last):
  File "/home/michael/git/pyrapl-test.py", line 12, in <module>
    foo()
  File "/home/michael/anaconda3/lib/python3.12/site-packages/pyRAPL/measurement.py", line 124, in wrapper_measure
    sensor.export()
  File "/home/michael/anaconda3/lib/python3.12/site-packages/pyRAPL/measurement.py", line 95, in export
    self._output.add(self._results)
  File "/home/michael/anaconda3/lib/python3.12/site-packages/pyRAPL/outputs/buffered_output.py", line 51, in add
    x['dram'] = result.dram[i]
                ~~~~~~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```

I made the following changes to fix locally:

1. *buffered_output.py*
  - Added condition to check if ```result.dram``` is ```None```
2. *dataframeoutput.py*
  - Concatenating data frames no longer works in Pandas 2.2.2
  - I've extended the BufferedOutput class (like *mongooutput.py*) and now lazily create the data frame when the data property is accessed

All unit tests pass on my machine.  Opening this pull request in case you find these fixes useful.  Thanks!